### PR TITLE
Gets rid of the provider config block warning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,3 @@
-provider "aws" { alias = "satellite" }
-provider "aws" { alias = "hub" }
-
 resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
   provider           = aws.satellite
   count              = local.create ? 1 : 0

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,10 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      configuration_aliases = [
+        aws.satellite,
+        aws.hub,
+      ]
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
# Gets rid of the provider config block warnins

## Description
Upcoming release tag: `v3.0.1`

The following warning is not displayed anymore:
```
│ Warning: Empty provider configuration blocks are not required
│
│   on .terraform/modules/tgw-satellite/main.tf line 1:
│    1: provider "aws" { alias = "satellite" }
│
│ Remove the aws.satellite provider block from module.tgw-satellite. Add aws.satellite to the list of configuration_aliases for aws in required_providers to define the provider configuration name.
│
│ (and one more similar warning elsewhere)
```


## Testing Instructions
N/A


## How to roll out
N/A

## Notes
N/A


## Demo
N/A
