### PR TITLE
Avoids errors due to version pinning mismatch

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.27.0"
+      version = "~> 4.30"
       configuration_aliases = [
         aws.satellite,
         aws.hub,


### PR DESCRIPTION
# Avoids errors due to version pinning mismatch

## Description
Sometimes there are different AWS provider versions present in one repo that pulls several modules.
Relaxing this version pinning increases the chances to avoid an error due to versions mismatch.

## Testing Instructions
N/A


## How to roll out
N/A


## Notes
Upcoming release: `v3.2.0`

## Demo
N/A